### PR TITLE
Update dom4j from 1.6.1 to 2.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,9 +103,9 @@
       <version>${maven.version}</version>
     </dependency>
     <dependency>
-      <groupId>dom4j</groupId>
+      <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
-      <version>1.6.1</version>
+      <version>2.1.3</version>
     </dependency>
     <dependency>
       <groupId>org.jvnet.maven-jellydoc-plugin</groupId>

--- a/src/main/java/org/kohsuke/stapler/TaglibDocMojo.java
+++ b/src/main/java/org/kohsuke/stapler/TaglibDocMojo.java
@@ -47,6 +47,7 @@ import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.DocumentFactory;
 import org.dom4j.Element;
+import org.dom4j.Node;
 import org.dom4j.io.SAXReader;
 import org.jvnet.maven.jellydoc.Attribute;
 import org.jvnet.maven.jellydoc.JellydocMojo;
@@ -237,9 +238,10 @@ public class TaglibDocMojo extends AbstractMojo implements MavenReport {
                 tag.doc("");
             } else {
                 tag.doc(doc.getText());
-                for(Element attr : (List<Element>)doc.selectNodes("s:attribute")) {
+                for (Node node : doc.selectNodes("s:attribute")) {
+                    Element attr = (Element) node;
                     Attribute aw = tag.attribute();
-                    for (org.dom4j.Attribute a : (List<org.dom4j.Attribute>) attr.attributes()) {
+                    for (org.dom4j.Attribute a : attr.attributes()) {
                         aw._attribute(a.getName(),a.getValue());
                     }
                     aw.doc(attr.getText());


### PR DESCRIPTION
Addresses the open security vulnerabilities: https://github.com/jenkinsci/maven-stapler-plugin/security/dependabot

The GAV coordinates changed, hence dependabot is not able to create a PR.

For reference, `dom4j:dom4j:1.6.1` was released in 2005, `org.dom4j:dom4j:2.1.3` was released in 2020, CVE free.