### PR TITLE
Maven 3 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,9 @@
     <revision>1.19</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
-    <maven.version>2.2.1</maven.version>
+    <maven.version>3.8.6</maven.version>
     <maven-plugin-tools.version>3.6.4</maven-plugin-tools.version>
+    <!-- TODO fix violations -->
     <spotbugs.threshold>High</spotbugs.threshold>
   </properties>
 
@@ -78,6 +79,11 @@
                 <enforceBytecodeVersion>
                   <maxJdkVersion>1.8</maxJdkVersion>
                 </enforceBytecodeVersion>
+                <requireUpperBoundDeps>
+                  <excludes combine.children="append">
+                    <exclude>xerces:xercesImpl</exclude>
+                  </excludes>
+                </requireUpperBoundDeps>
               </rules>
             </configuration>
           </execution>
@@ -86,47 +92,47 @@
     </plugins>
   </build>
   
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-artifact</artifactId>
+        <version>${maven.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-core</artifactId>
+        <version>${maven.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-model</artifactId>
+        <version>${maven.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-plugin-api</artifactId>
+        <version>${maven.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.shared</groupId>
+        <artifactId>maven-shared-utils</artifactId>
+        <version>3.3.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-component-annotations</artifactId>
+        <version>2.1.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.4.2</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-plugin-api</artifactId>
-      <version>${maven.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
-      <version>${maven.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-artifact</artifactId>
-      <version>${maven.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.dom4j</groupId>
-      <artifactId>dom4j</artifactId>
-      <version>2.1.3</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jvnet.maven-jellydoc-plugin</groupId>
-      <artifactId>maven-jellydoc-plugin</artifactId>
-      <version>1.5</version>
-      <exclusions>
-        <exclusion>
-          <groupId>xml-apis</groupId>
-          <artifactId>xml-apis</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.ibm.icu</groupId>
-          <artifactId>icu4j</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.11.0</version>
-    </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
@@ -139,10 +145,60 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.11.0</version>
+    </dependency>
+    <dependency>
+      <groupId>jaxen</groupId>
+      <artifactId>jaxen</artifactId>
+      <version>1.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-artifact-transfer</artifactId>
+      <version>0.13.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.dom4j</groupId>
+      <artifactId>dom4j</artifactId>
+      <version>2.1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jvnet.maven-jellydoc-plugin</groupId>
+      <artifactId>maven-jellydoc-plugin</artifactId>
+      <version>1.9</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <version>${maven-plugin-tools.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/kohsuke/stapler/TaglibDocMojo.java
+++ b/src/main/java/org/kohsuke/stapler/TaglibDocMojo.java
@@ -27,8 +27,7 @@ import com.sun.xml.txw2.output.StreamSerializer;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
-import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.ArtifactResolver;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -42,6 +41,7 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
 import org.apache.maven.reporting.MavenReport;
 import org.apache.maven.reporting.MavenReportException;
+import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
 import org.codehaus.doxia.sink.Sink;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
@@ -85,6 +85,12 @@ public class TaglibDocMojo extends AbstractMojo implements MavenReport {
     protected MavenProject project;
 
     /**
+     * The Maven session object.
+     */
+    @Parameter(defaultValue = "${session}", required = true, readonly = true)
+    protected MavenSession session;
+
+    /**
      * The plugin dependencies.
      */
     @Parameter(defaultValue = "${plugin.artifacts}", required = true, readonly = true)
@@ -116,12 +122,6 @@ public class TaglibDocMojo extends AbstractMojo implements MavenReport {
     @Component
     private ArtifactResolver resolver;
 
-    /**
-     * The local repository where the artifacts are located.
-     */
-    @Parameter(defaultValue = "${localRepository}")
-    private ArtifactRepository localRepository;
-
     @Component
     private MavenProjectHelper helper;
 
@@ -144,7 +144,7 @@ public class TaglibDocMojo extends AbstractMojo implements MavenReport {
             };
             jellydoc.factory = factory;
             jellydoc.helper = helper;
-            jellydoc.localRepository = localRepository;
+            jellydoc.session = session;
             jellydoc.project = project;
             jellydoc.resolver = resolver;
         }


### PR DESCRIPTION
Does not currently compile, because we depend on `maven-jellydoc-plugin`, which itself is still using Maven 2 APIs.

I have started [a mailing list thread](https://groups.google.com/g/jenkinsci-dev/c/cQSf2qP7jbc/m/VJHxxgJ8AQAJ) to track the transfer of the `maven-jellydoc-plugin` to the @jenkinsci GitHub organization so that it can be updated for compatibility with future Maven releases, unblocking this PR.

@kohsuke Friendly gentle ping about this thread. If you have some time, would you be willing to transfer `maven-jellydoc-plugin` to our GitHub organization? Thank you in advance for your time.